### PR TITLE
Fix english activate light mode copy key

### DIFF
--- a/Darky/DarkMode Switcher/en-GB.lproj/Localizable.strings
+++ b/Darky/DarkMode Switcher/en-GB.lproj/Localizable.strings
@@ -7,7 +7,7 @@
  */
 
 "activate_dark_mode" = "Dark Mode ON";
-"desactivate_dark_mode" = "Dark Mode OFF";
+"activate_light_mode" = "Dark Mode OFF";
 "enable_start_up_login" = "Start up when launch";
 "settings" = "Preferences...";
 "quit_app" = "Quit App";


### PR DESCRIPTION
Currently the following is seen in the english version
<img width="248" alt="image" src="https://user-images.githubusercontent.com/11362913/146308623-a3658092-0cac-4e9b-acb7-5b31b3716547.png">
